### PR TITLE
CSV export

### DIFF
--- a/Demo/Person.cs
+++ b/Demo/Person.cs
@@ -7,10 +7,10 @@ internal sealed class Person
     [Appearance(Order = 1, TextAlign = TextAlign.Right)]
     public int Id { get; set; }
 
-    [Appearance(Order = 3)]
+    [Appearance(Order = 3, EncapsulateContent = true)]
     public string Name { get; set; } = string.Empty;
 
-    [Appearance(Order = 2)]
+    [Appearance(Order = 2, EncapsulateContent = true)]
     public string Title { get; set; } = string.Empty;
 
     [Appearance(Ignore = true)]

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -23,6 +23,8 @@ internal static class Program
         EmptyEntryTest();
 
         WrongMethodTest();
+
+        CsvEncapsulateContentTest();
     }
 
     private static void TableTest()
@@ -34,8 +36,8 @@ internal static class Program
         var overrideList = new List<OverrideAttributeEntry>
         {
             new("Id", new AppearanceAttribute(order: 1, textAlign: TextAlign.Left)),
-            new("Name", new AppearanceAttribute(order: 3)),
-            new("Title", new AppearanceAttribute(order: 2)),
+            new("Name", new AppearanceAttribute(order: 3, encapsulateContent: true)),
+            new("Title", new AppearanceAttribute(order: 2, encapsulateContent: true)),
             new("DepartmentId", new AppearanceAttribute(true)),
             new("Locked", new AppearanceAttribute("User locked", order: 4)),
             new("SomeValue", new AppearanceAttribute("Some value", order: 5, format: "N0")),
@@ -201,6 +203,22 @@ internal static class Program
         }
 
         Console.WriteLine();
+    }
+
+    private static void CsvEncapsulateContentTest()
+    {
+        Console.WriteLine("CSV - Encapsulate content test");
+        Console.WriteLine("==============================");
+
+        var persons = Helper.CreatePersonList();
+
+        var content = persons.CreateTable(new TableCreatorOptions
+        {
+            OutputType = OutputType.Csv,
+            AddHeader = false
+        });
+
+        Console.WriteLine(content);
     }
 }
 

--- a/ZimLabs.TableCreator/AppearanceAttribute.cs
+++ b/ZimLabs.TableCreator/AppearanceAttribute.cs
@@ -7,6 +7,46 @@
 public sealed class AppearanceAttribute : Attribute
 {
     /// <summary>
+    /// Gets or sets the name which should be used for the <i>column</i>
+    /// <para/>
+    /// With this property you can overwrite the original property name
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the format of the value (default = <see cref="string.Empty"/>)
+    /// <para />
+    /// For example: <c>yyyy-MM-dd HH:mm:ss</c> will produce <c>2023-12-15 20:15:00</c> if the property is a <see cref="DateTime"/>
+    /// <para />
+    /// For more information about the format see <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/formatting-types">MSDN - formatting types</a>
+    /// </summary>
+    public string Format { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the text align (will be ignored when the output type is <see cref="OutputType.Csv"/>) (default = <see cref="TextAlign.Left"/>)
+    /// </summary>
+    public TextAlign TextAlign { get; set; } = TextAlign.Left;
+
+    /// <summary>
+    /// Gets or sets the value which indicates if the property should be ignored. If <see langword="true"/> the other settings will be ignored (default = <see langword="false"/>)
+    /// </summary>
+    public bool Ignore { get; set; }
+
+    /// <summary>
+    /// Gets or sets the order of the property (default = <c>-1</c>).
+    /// <para/>
+    /// <b>NOTE</b>: Properties that do not have an order value are sorted by the position in the class.
+    /// </summary>
+    public int Order { get; set; } = -1;
+
+    /// <summary>
+    /// Gets or sets the value which indicates if the content should be encapsulated by quotes (default = <see langword="false"/>)
+    /// <para />
+    /// <b>Example</b>: <c>...;"Some content";...</c>
+    /// </summary>
+    public bool EncapsulateContent { get; set; }
+
+    /// <summary>
     /// Creates a new empty instance with the default values
     /// </summary>
     public AppearanceAttribute() { }
@@ -35,45 +75,18 @@ public sealed class AppearanceAttribute : Attribute
     /// <para />
     /// <b>NOTE</b>: Properties that do not have an order value are sorted by the position in the class
     /// </param>
-    public AppearanceAttribute(string name = "", string format = "", TextAlign textAlign = TextAlign.Left, int order = -1)
+    /// <param name="encapsulateContent">
+    /// <see langword="true"/> to encapsulate the content of the property with quotes.
+    /// <para />
+    /// <b>Example</b>: <c>...;"Some content";...</c>
+    /// </param>
+    public AppearanceAttribute(string name = "", string format = "", TextAlign textAlign = TextAlign.Left, int order = -1, bool encapsulateContent = false)
     {
         Name = name;
         Format = format;
         TextAlign = textAlign;
         Ignore = false;
         Order = order;
+        EncapsulateContent = encapsulateContent;
     }
-
-    /// <summary>
-    /// Gets or sets the name which should be used for the <i>column</i>
-    /// <para/>
-    /// With this property you can overwrite the original property name
-    /// </summary>
-    public string Name { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the format of the value
-    /// <para />
-    /// For example: <c>yyyy-MM-dd HH:mm:ss</c> will produce <c>2023-12-15 20:15:00</c> if the property is a <see cref="DateTime"/>
-    /// <para />
-    /// For more information about the format see <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/formatting-types">MSDN - formatting types</a>
-    /// </summary>
-    public string Format { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the text align (will be ignored when the output type is <see cref="OutputType.Csv"/>)
-    /// </summary>
-    public TextAlign TextAlign { get; set; } = TextAlign.Left;
-
-    /// <summary>
-    /// Gets or sets the value which indicates if the property should be ignored. If <see langword="true"/> the other settings will be ignored.
-    /// </summary>
-    public bool Ignore { get; set; }
-
-    /// <summary>
-    /// Gets or sets the order of the property.
-    /// <para/>
-    /// <b>NOTE</b>: Properties that do not have an order value are sorted by the position in the class.
-    /// </summary>
-    public int Order { get; set; } = -1;
 }

--- a/ZimLabs.TableCreator/DataObjects/Property.cs
+++ b/ZimLabs.TableCreator/DataObjects/Property.cs
@@ -40,6 +40,13 @@ internal sealed class Property(string name, AppearanceAttribute? appearance)
     public int Order => Appearance.Order;
 
     /// <summary>
+    /// Gets or sets the value which indicates if the content should be encapsulated by quotes
+    /// <para />
+    /// <b>Example</b>: <c>...;"Some content";...</c>
+    /// </summary>
+    public bool EncapsulateContent => Appearance.EncapsulateContent;
+
+    /// <summary>
     /// Converts a <see cref="PropertyInfo"/> into a <see cref="Property"/>
     /// </summary>
     /// <param name="prop">The original property</param>

--- a/ZimLabs.TableCreator/DataObjects/TableCreatorListOptions.cs
+++ b/ZimLabs.TableCreator/DataObjects/TableCreatorListOptions.cs
@@ -1,0 +1,35 @@
+﻿using System.Text;
+
+namespace ZimLabs.TableCreator.DataObjects;
+
+/// <summary>
+/// Provides the options for the list creation
+/// </summary>
+public sealed class TableCreatorListOptions
+{
+    /// <summary>
+    /// Gets or sets the desired list type (default = <see cref="ListType.Bullets"/>)
+    /// </summary>
+    public ListType ListType { get; set; } = ListType.Bullets;
+
+    /// <summary>
+    /// Gets or sets the value which indicates if the properties should be aligned (default = <see langword="false"/>)
+    /// <para />
+    /// <see langword="true"/> to add dots to the end of the properties so that all properties have the same length
+    /// </summary>
+    public bool AlignProperties { get; set; }
+
+    /// <summary>
+    /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>)
+    /// <para />
+    /// This value is only used in the file export
+    /// </summary>
+    public Encoding Encoding { get; set; } = Encoding.UTF8;
+
+    /// <summary>
+    /// Gets or sets the list with the override entries.
+    /// <para />
+    /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored
+    /// </summary>
+    public List<OverrideAttributeEntry> OverrideList { get; set; } = [];
+}

--- a/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
+++ b/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
@@ -1,0 +1,47 @@
+﻿using System.Text;
+
+namespace ZimLabs.TableCreator.DataObjects;
+
+/// <summary>
+/// Provides the options for the table creation
+/// </summary>
+public sealed class TableCreatorOptions
+{
+    /// <summary>
+    /// Gets or sets the desired output type (default = <see cref="OutputType.Default"/>)
+    /// </summary>
+    public OutputType OutputType { get; set; } = OutputType.Default;
+
+    /// <summary>
+    /// Gets or sets the value which indicates if a "line number" should be added to the list (default = <see langword="false"/>)
+    /// </summary>
+    public bool PrintLineNumbers { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the delimiter which should be used for the CSV export. (default = <c>;</c>)
+    /// <para />
+    /// <b>Note</b>: This value is only needed when the <see cref="OutputType"/> is set to <see cref="OutputType.Csv"/>
+    /// </summary>
+    public string Delimiter { get; set; } = ";";
+
+    /// <summary>
+    /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>)
+    /// <para />
+    /// This value is only used in the file export
+    /// </summary>
+    public Encoding Encoding { get; set; } = Encoding.UTF8;
+
+    /// <summary>
+    /// Gets or sets the value which indicates if a header should be added to the CSV content (default = <see langword="true"/>)
+    /// <para />
+    /// <b>Note</b>: This options is only needed for the CSV Export
+    /// </summary>
+    public bool AddHeader { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the list with the override entries.
+    /// <para />
+    /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored
+    /// </summary>
+    public List<OverrideAttributeEntry> OverrideList { get; set; } = [];
+}

--- a/ZimLabs.TableCreator/TableCreator.cs
+++ b/ZimLabs.TableCreator/TableCreator.cs
@@ -19,18 +19,19 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static string CreateTable<T>(this IEnumerable<T> list, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
         // Check if the list is "null"
         ArgumentNullException.ThrowIfNull(list);
 
         if (outputType == OutputType.Csv)
-            return TableHelper.CreateCsv(list, delimiter, printLineNumbers, overrideList);
+            return TableHelper.CreateCsv(list, delimiter, printLineNumbers, addHeader, overrideList);
 
         // Get the properties of the given type
         var properties = TableHelper.GetProperties<T>(overrideList);
@@ -51,7 +52,7 @@ public static class TableCreator
         var count = 1;
         printList.AddRange(list.Select(entry => new LineEntry(count++)
         {
-            Values = properties.Select(s => new ValueEntry(s.Name, TableHelper.GetPropertyValue(entry, s))).ToList()
+            Values = properties.Select(s => new ValueEntry(s.Name, TableHelper.GetPropertyValue(entry, s, false))).ToList()
         }));
 
         // 3 = "Row"
@@ -65,6 +66,19 @@ public static class TableCreator
     }
 
     /// <summary>
+    /// Converts the given list into a "table"
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="list">The list with the values</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The created table</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static string CreateTable<T>(this IEnumerable<T> list, TableCreatorOptions options) where T : class
+    {
+        return CreateTable(list, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader, options.OverrideList);
+    }
+
+    /// <summary>
     /// Converts the given list into a "table" and save it into the specified file
     /// </summary>
     /// <typeparam name="T">The type of the values</typeparam>
@@ -73,14 +87,15 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static void SaveTable<T>(this IEnumerable<T> list, string filepath,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        list.SaveTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, overrideList);
+        list.SaveTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader, overrideList);
     }
 
     /// <summary>
@@ -93,14 +108,15 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static void SaveTable<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        var result = CreateTable(list, outputType, printLineNumbers, delimiter, overrideList);
+        var result = CreateTable(list, outputType, printLineNumbers, delimiter, addHeader, overrideList);
 
         File.WriteAllText(filepath, result, encoding);
     }
@@ -111,18 +127,34 @@ public static class TableCreator
     /// <typeparam name="T">The type of the values</typeparam>
     /// <param name="list">The list with the values</param>
     /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static void SaveTable<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)
+        where T : class
+    {
+        SaveTable(list, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader, options.OverrideList);
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="list">The list with the values</param>
+    /// <param name="filepath">The path of the destination file</param>
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        return list.SaveTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, overrideList);
+        return list.SaveTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader,
+            overrideList);
     }
 
     /// <summary>
@@ -135,17 +167,32 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+    public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, Encoding encoding, OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        var result = CreateTable(list, outputType, printLineNumbers, delimiter, overrideList);
+        var result = CreateTable(list, outputType, printLineNumbers, delimiter, addHeader, overrideList);
 
         return File.WriteAllTextAsync(filepath, result, encoding);
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="list">The list with the values</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)
+        where T : class
+    {
+        return SaveTableAsync(list, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
+            options.Delimiter, options.AddHeader, options.OverrideList);
     }
 
     #endregion
@@ -159,16 +206,17 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static string CreateTable(this DataTable table, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
         ArgumentNullException.ThrowIfNull(table);
 
         if (outputType == OutputType.Csv)
-            return TableHelper.CreateCsv(table, delimiter, printLineNumbers, overrideList);
+            return TableHelper.CreateCsv(table, delimiter, printLineNumbers, addHeader, overrideList);
 
         // Get the properties of the given type
         var properties = TableHelper.GetProperties(table, overrideList);
@@ -191,7 +239,7 @@ public static class TableCreator
             select new LineEntry(count++)
             {
                 Values = properties.Select(s =>
-                    new ValueEntry(s.Name, TableHelper.GetPropertyValue(row, s.Name, s.Appearance.Format))).ToList()
+                    new ValueEntry(s.Name, TableHelper.GetPropertyValue(row, s.Name, s.Appearance.Format, false))).ToList()
             });
 
         // 3 chars for "row"
@@ -204,6 +252,19 @@ public static class TableCreator
     }
 
     /// <summary>
+    /// Converts the given list into a "table"
+    /// </summary>
+    /// <param name="table">The table with the data</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The created table</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static string CreateTable(this DataTable table, TableCreatorOptions options)
+    {
+        return CreateTable(table, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader,
+            options.OverrideList);
+    }
+
+    /// <summary>
     /// Converts the given list into a "table" and save it into the specified file
     /// </summary>
     /// <param name="table">The table with the data</param>
@@ -211,13 +272,14 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static void SaveTable(this DataTable table, string filepath,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+    public static void SaveTable(this DataTable table, string filepath, OutputType outputType = OutputType.Default,
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true,
+        List<OverrideAttributeEntry>? overrideList = null)
     {
-        table.SaveTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, overrideList);
+        table.SaveTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader, overrideList);
     }
 
     /// <summary>
@@ -229,13 +291,14 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static void SaveTable(this DataTable table, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
-        var result = CreateTable(table, outputType, printLineNumbers, delimiter, overrideList);
+        var result = CreateTable(table, outputType, printLineNumbers, delimiter, addHeader, overrideList);
 
         File.WriteAllText(filepath, result, encoding);
     }
@@ -245,17 +308,32 @@ public static class TableCreator
     /// </summary>
     /// <param name="table">The table with the data</param>
     /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static void SaveTable(this DataTable table, string filepath, TableCreatorOptions options)
+    {
+        SaveTable(table, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers, options.Delimiter,
+            options.AddHeader, options.OverrideList);
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <param name="table">The table with the data</param>
+    /// <param name="filepath">The path of the destination file</param>
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync(this DataTable table, string filepath,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+    public static Task SaveTableAsync(this DataTable table, string filepath, OutputType outputType = OutputType.Default,
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true,
+        List<OverrideAttributeEntry>? overrideList = null)
     {
-        return table.SaveTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, overrideList);
+        return table.SaveTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader,
+            overrideList);
     }
 
     /// <summary>
@@ -267,16 +345,31 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static Task SaveTableAsync(this DataTable table, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
-        var result = CreateTable(table, outputType, printLineNumbers, delimiter, overrideList);
+        var result = CreateTable(table, outputType, printLineNumbers, delimiter, addHeader, overrideList);
 
         return File.WriteAllTextAsync(filepath, result, encoding);
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <param name="table">The table with the data</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static Task SaveTableAsync(this DataTable table, string filepath, TableCreatorOptions options)
+    {
+        return SaveTableAsync(table, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
+            options.Delimiter, options.AddHeader, options.OverrideList);
     }
 
     #endregion
@@ -289,11 +382,11 @@ public static class TableCreator
     /// <typeparam name="T">The type of the value</typeparam>
     /// <param name="value">The value</param>
     /// <param name="type">The desired list type</param>
-    /// <param name="alignProperties">true to add dots to the end of the properties so that all properties have the same length</param>
+    /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The list</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static string CreateValueList<T>(this T value, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null) 
         where T : class
@@ -319,10 +412,24 @@ public static class TableCreator
             var dotLength = alignProperties ? maxLength - property.CustomName.Length : 0;
             sb.AppendLine(
                 $"{listIndicator} {property.CustomName}{"".PadRight(dotLength, '.')}: " +
-                $"{TableHelper.GetPropertyValue(value, property)}");
+                $"{TableHelper.GetPropertyValue(value, property, false)}");
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Creates a list of the properties with its values
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="options">The options for the list creation</param>
+    /// <returns>The list</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static string CreateValueList<T>(this T value, TableCreatorListOptions options) where T : class
+    {
+        return CreateValueList(value, options.ListType, options.AlignProperties, options.OverrideList);
     }
 
     /// <summary>
@@ -333,13 +440,14 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static string CreateValueTable<T>(this T value, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
-        where T : class
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true,
+        List<OverrideAttributeEntry>? overrideList = null) where T : class
     {
         if (TableHelper.IsList<T>())
         {
@@ -352,10 +460,24 @@ public static class TableCreator
         var properties = TableHelper.GetProperties<T>(overrideList);
 
         var data = (from property in properties
-                    let tmpValue = TableHelper.GetPropertyValue(value, property)
-                    select new KeyValueEntry(property.CustomName, tmpValue)).ToList();
+            let tmpValue = TableHelper.GetPropertyValue(value, property, outputType == OutputType.Csv)
+            select new KeyValueEntry(property.CustomName, tmpValue)).ToList();
 
-        return CreateTable(data, outputType, printLineNumbers, delimiter);
+        return CreateTable(data, outputType, printLineNumbers, delimiter, addHeader, overrideList);
+    }
+
+    /// <summary>
+    /// Converts the given value into a "table" (Key, Value columns)
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The created table</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static string CreateValueTable<T>(this T value, TableCreatorOptions options) where T : class
+    {
+        return CreateValueTable(value, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader, options.OverrideList);
     }
 
     /// <summary>
@@ -365,10 +487,10 @@ public static class TableCreator
     /// <param name="value">The value</param>
     /// <param name="filepath">The path of the destination file</param>
     /// <param name="type">The desired list type</param>
-    /// <param name="alignProperties">true to add dots to the end of the properties so that all properties have the same length</param>
+    /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static void SaveValue<T>(this T value, string filepath, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
@@ -386,9 +508,9 @@ public static class TableCreator
     /// <param name="filepath">The path of the destination file</param>
     /// <param name="encoding">The encoding of the file</param>
     /// <param name="type">The desired list type</param>
-    /// <param name="alignProperties">true to add dots to the end of the properties so that all properties have the same length</param>
+    /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     public static void SaveValue<T>(this T value, string filepath, Encoding encoding, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -400,6 +522,20 @@ public static class TableCreator
     }
 
     /// <summary>
+    /// Creates a list of the properties with its values and saves it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the list creation</param>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    public static void SaveValue<T>(this T value, string filepath, TableCreatorListOptions options) where T : class
+    {
+        SaveValue(value, filepath, options.Encoding, options.ListType, options.AlignProperties, options.OverrideList);
+    }
+
+    /// <summary>
     /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
     /// </summary>
     /// <typeparam name="T">The type of the value</typeparam>
@@ -408,16 +544,17 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static void SaveValueAsTable<T>(this T value, string filepath, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        value.SaveValueAsTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, overrideList);
+        value.SaveValueAsTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader, overrideList);
     }
 
     /// <summary>
@@ -430,12 +567,13 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static void SaveValueAsTable<T>(this T value, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
         if (TableHelper.IsList<T>())
         {
@@ -450,10 +588,25 @@ public static class TableCreator
         var data = properties.Select(s => new
         {
             Key = s.CustomName,
-            Value = TableHelper.GetPropertyValue(value, s)
+            Value = TableHelper.GetPropertyValue(value, s, outputType == OutputType.Csv)
         });
 
-        data.SaveTable(filepath, encoding, outputType, printLineNumbers, delimiter);
+        data.SaveTable(filepath, encoding, outputType, printLineNumbers, delimiter, addHeader);
+    }
+
+    /// <summary>
+    /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static void SaveValueAsTable<T>(this T value, string filepath, TableCreatorOptions options) where T : class
+    {
+        SaveValueAsTable(value, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
+            options.Delimiter, options.AddHeader, options.OverrideList);
     }
 
     /// <summary>
@@ -463,10 +616,10 @@ public static class TableCreator
     /// <param name="value">The value</param>
     /// <param name="filepath">The path of the destination file</param>
     /// <param name="type">The desired list type</param>
-    /// <param name="alignProperties">true to add dots to the end of the properties so that all properties have the same length</param>
+    /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     public static Task SaveValueAsync<T>(this T value, string filepath, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -485,11 +638,11 @@ public static class TableCreator
     /// <param name="filepath">The path of the destination file</param>
     /// <param name="encoding">The encoding of the file</param>
     /// <param name="type">The desired list type</param>
-    /// <param name="alignProperties">true to add dots to the end of the properties so that all properties have the same length</param>
+    /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
-    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <returns>The awaitable task</returns>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     public static Task SaveValueAsync<T>(this T value, string filepath, Encoding encoding, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
@@ -497,6 +650,22 @@ public static class TableCreator
         var result = value.CreateValueList(type, alignProperties, overrideList);
 
         return File.WriteAllTextAsync(filepath, result, encoding);
+    }
+
+    /// <summary>
+    /// Creates a list of the properties with its values and saves it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the list creation</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    public static Task SaveValueAsync<T>(this T value, string filepath, TableCreatorListOptions options) where T : class
+    {
+        return SaveValueAsync(value, filepath, options.Encoding, options.ListType, options.AlignProperties,
+            options.OverrideList);
     }
 
     /// <summary>
@@ -508,17 +677,20 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
     /// <returns>The awaitable task</returns>
-    public static Task SaveValueAsTableAsync<T>(this T value, string filepath, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static Task SaveValueAsTableAsync<T>(this T value, string filepath,
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        return value.SaveValueAsTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, overrideList);
+        return value.SaveValueAsTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader,
+            overrideList);
     }
 
     /// <summary>
@@ -531,13 +703,14 @@ public static class TableCreator
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is a assignable from IEnumerable</exception>
     /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static Task SaveValueAsTableAsync<T>(this T value, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
         if (TableHelper.IsList<T>())
         {
@@ -552,10 +725,27 @@ public static class TableCreator
         var data = properties.Select(s => new
         {
             Key = s.CustomName,
-            Value = TableHelper.GetPropertyValue(value, s)
+            Value = TableHelper.GetPropertyValue(value, s, outputType == OutputType.Csv)
         });
 
-        return data.SaveTableAsync(filepath, encoding, outputType, printLineNumbers, delimiter);
+        return data.SaveTableAsync(filepath, encoding, outputType, printLineNumbers, delimiter, addHeader);
+    }
+
+    /// <summary>
+    /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static Task SaveValueAsTableAsync<T>(this T value, string filepath, TableCreatorOptions options)
+        where T : class
+    {
+        return SaveValueAsTableAsync(value, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
+            options.Delimiter, options.AddHeader, options.OverrideList);
     }
 
     #endregion

--- a/ZimLabs.TableCreator/ZimLabs.TableCreator.csproj
+++ b/ZimLabs.TableCreator/ZimLabs.TableCreator.csproj
@@ -9,7 +9,7 @@
       <Copyright>Andreas Pouwels</Copyright>
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
       <Title>ZimLabs.TableCreator</Title>
-      <Version>2.0.2</Version>
+      <Version>2.1.1</Version>
       <PackageProjectUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</PackageProjectUrl>
       <PackageIcon>Logo.png</PackageIcon>
       <PackageReadmeFile>readme.md</PackageReadmeFile>

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ This library is not very special :) It takes a list of objects and creates an AS
 - [Usage](#usage)
 - [Known issues](#known-issues)
 - [Changelog](#changelog)
+    - [Version 2.1.1](#version-211)
+    - [Version 2.1.0](#version-210)
     - [Version 2.0.2](#version-202)
     - [Version 2.0.1](#version-201)
     - [Version 2.0.0](#version-200)
@@ -154,6 +156,12 @@ The specified type is not supported by this method. Please choose "CreateTable" 
 Sorry for the inconvenience.
 
 ## Changelog
+
+### Version 2.1.1
+
+- Option `addHeader` addded, with which you can decide whether the CSV content should contain a header line.
+- Added classes for the various options to improve clarity (`TableCreateOptions` and `TableCreatorListOptions`).
+- Appearance attribute adjusted. It is now possible to specify whether the content of a property should be encapsulate in quotation marks.
 
 ### Version 2.1.0
 


### PR DESCRIPTION
## Whats new?

- Option `addHeader` addded, with which you can decide whether the CSV content should contain a header line.
- Added classes for the various options to improve clarity (`TableCreateOptions` and `TableCreatorListOptions`).
- Appearance attribute adjusted. It is now possible to specify whether the content of a property should be encapsulate in quotation marks.