### PR TITLE
.NET 9 / Encapsulate text values

### DIFF
--- a/Demo/BenchmarkTest.cs
+++ b/Demo/BenchmarkTest.cs
@@ -1,11 +1,11 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using ZimLabs.TableCreator;
+using ZimLabs.TableCreator.DataObjects;
 
 namespace Demo;
 
-[SimpleJob(RuntimeMoniker.Net70, baseline: true)]
-[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net90)]
 [RPlotExporter]
 public class BenchmarkTest
 {
@@ -17,7 +17,7 @@ public class BenchmarkTest
     {
         var dummyData = Helper.CreatePersonList();
 
-        _ = dummyData.CreateTable();
+        _ = dummyData.CreateTable(new TableCreatorOptions());
     }
     #pragma warning restore CA1822 // Mark members as static
 
@@ -26,7 +26,7 @@ public class BenchmarkTest
     {
         var dummyData = Helper.CreatePersonList();
 
-        dummyData.SaveTable(_testFile);
+        dummyData.SaveTable(_testFile, new TableCreatorOptions());
     }
 
     [Benchmark]
@@ -34,6 +34,6 @@ public class BenchmarkTest
     {
         var dummyData = Helper.CreatePersonList();
 
-        return dummyData.SaveTableAsync(_testFile);
+        return dummyData.SaveTableAsync(_testFile, new TableCreatorOptions());
     }
 }

--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,18 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ZimLabs.TableCreator\ZimLabs.TableCreator.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Demo/Person.cs
+++ b/Demo/Person.cs
@@ -10,7 +10,7 @@ internal sealed class Person
     [Appearance(Order = 3, EncapsulateContent = true)]
     public string Name { get; set; } = string.Empty;
 
-    [Appearance(Order = 2, EncapsulateContent = true)]
+    [Appearance(Order = 2)]
     public string Title { get; set; } = string.Empty;
 
     [Appearance(Ignore = true)]

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -25,6 +25,12 @@ internal static class Program
         WrongMethodTest();
 
         CsvEncapsulateContentTest();
+
+        // Run the benchmark
+        Console.WriteLine("Benchmarks");
+        Console.WriteLine("==========");
+        Console.WriteLine();
+        BenchmarkRunner.Run<BenchmarkTest>();
     }
 
     private static void TableTest()
@@ -51,7 +57,10 @@ internal static class Program
             var tmpValue = $"Output type: {outputType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(dataTable.CreateTable(outputType, overrideList: overrideList));
+            Console.WriteLine(dataTable.CreateTable(new TableCreatorOptions
+            {
+                OutputType = outputType
+            }));
         }
     }
 
@@ -66,7 +75,10 @@ internal static class Program
             var tmpValue = $"Output type: {outputType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(dummyList.CreateTable(outputType));
+            Console.WriteLine(dummyList.CreateTable(new TableCreatorOptions
+            {
+                OutputType = outputType
+            }));
         }
     }
 
@@ -81,7 +93,11 @@ internal static class Program
             var tmpValue = $"List type: {listType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(entry!.CreateValueList(listType, true));
+            Console.WriteLine(entry.CreateValueList(new TableCreatorListOptions
+            {
+                ListType = listType,
+                AlignProperties = true
+            }));
         }
 
         Console.WriteLine("Single class entry (w/o alignment)");
@@ -91,7 +107,10 @@ internal static class Program
             var tmpValue = $"List type: {listType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(entry!.CreateValueList(listType));
+            Console.WriteLine(entry.CreateValueList(new TableCreatorListOptions
+            {
+                ListType = listType
+            }));
         }
     }
 
@@ -113,7 +132,10 @@ internal static class Program
             var tmpValue = $"Output type: {outputType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(list.CreateTable(outputType));
+            Console.WriteLine(list.CreateTable(new TableCreatorOptions
+            {
+                OutputType = outputType
+            }));
         }
     }
 
@@ -135,7 +157,11 @@ internal static class Program
             var tmpValue = $"List type: {listType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(entry!.CreateValueList(listType, true));
+            Console.WriteLine(entry!.CreateValueList(new TableCreatorListOptions
+            {
+                ListType = listType,
+                AlignProperties = true
+            }));
         }
 
         Console.WriteLine("Single anonymous entry test (w/o alignment)");
@@ -145,7 +171,10 @@ internal static class Program
             var tmpValue = $"List type: {listType}";
             Console.WriteLine(tmpValue);
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
-            Console.WriteLine(entry!.CreateValueList(listType));
+            Console.WriteLine(entry!.CreateValueList(new TableCreatorListOptions
+            {
+                ListType = listType
+            }));
         }
     }
 
@@ -157,7 +186,7 @@ internal static class Program
 
         try
         {
-            _ = emptyList!.CreateTable();
+            _ = emptyList!.CreateTable(new TableCreatorOptions());
         }
         catch (Exception ex)
         {
@@ -176,7 +205,7 @@ internal static class Program
 
         try
         {
-            _ = person!.CreateValueTable();
+            _ = person!.CreateValueTable(new TableCreatorOptions());
         }
         catch (Exception ex)
         {
@@ -195,7 +224,7 @@ internal static class Program
 
         try
         {
-            persons.CreateValueList();
+            persons.CreateValueList(new TableCreatorListOptions());
         }
         catch (Exception ex)
         {
@@ -207,15 +236,25 @@ internal static class Program
 
     private static void CsvEncapsulateContentTest()
     {
-        Console.WriteLine("CSV - Encapsulate content test");
-        Console.WriteLine("==============================");
+        Console.WriteLine("CSV - Encapsulate content test (only name)");
+        Console.WriteLine("==========================================");
 
         var persons = Helper.CreatePersonList();
 
         var content = persons.CreateTable(new TableCreatorOptions
         {
+            OutputType = OutputType.Csv
+        });
+
+        Console.WriteLine(content);
+
+        Console.WriteLine("CSV - Encapsulate content test (all text values)");
+        Console.WriteLine("================================================");
+
+        content = persons.CreateTable(new TableCreatorOptions
+        {
             OutputType = OutputType.Csv,
-            AddHeader = false
+            EncapsulateText = true
         });
 
         Console.WriteLine(content);

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -59,7 +59,8 @@ internal static class Program
             Console.WriteLine("-".PadRight(tmpValue.Length, '-'));
             Console.WriteLine(dataTable.CreateTable(new TableCreatorOptions
             {
-                OutputType = outputType
+                OutputType = outputType,
+                OverrideList = overrideList
             }));
         }
     }

--- a/ZimLabs.TableCreator/DataObjects/TableCreatorListOptions.cs
+++ b/ZimLabs.TableCreator/DataObjects/TableCreatorListOptions.cs
@@ -8,28 +8,31 @@ namespace ZimLabs.TableCreator.DataObjects;
 public sealed class TableCreatorListOptions
 {
     /// <summary>
-    /// Gets or sets the desired list type (default = <see cref="ListType.Bullets"/>)
+    /// Gets or sets the desired list type (default = <see cref="ListType.Bullets"/>).
     /// </summary>
-    public ListType ListType { get; set; } = ListType.Bullets;
+    public ListType ListType { get; init; } = ListType.Bullets;
 
     /// <summary>
-    /// Gets or sets the value which indicates if the properties should be aligned (default = <see langword="false"/>)
-    /// <para />
-    /// <see langword="true"/> to add dots to the end of the properties so that all properties have the same length
+    /// Gets or sets the value which indicates if the properties should be aligned (default = <see langword="false"/>).
     /// </summary>
-    public bool AlignProperties { get; set; }
+    /// <remarks>
+    /// <see langword="true"/> to add dots to the end of the properties so that all properties have the same length.
+    /// </remarks>
+    public bool AlignProperties { get; init; }
 
     /// <summary>
-    /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>)
-    /// <para />
-    /// This value is only used in the file export
+    /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>).
     /// </summary>
-    public Encoding Encoding { get; set; } = Encoding.UTF8;
+    /// <remarks>
+    /// This value is only used in the file export.
+    /// </remarks>
+    public Encoding Encoding { get; init; } = Encoding.UTF8;
 
     /// <summary>
     /// Gets or sets the list with the override entries.
-    /// <para />
-    /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored
     /// </summary>
-    public List<OverrideAttributeEntry> OverrideList { get; set; } = [];
+    /// <remarks>
+    /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored.
+    /// </remarks>
+    public List<OverrideAttributeEntry> OverrideList { get; init; } = [];
 }

--- a/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
+++ b/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
@@ -18,7 +18,7 @@ public sealed class TableCreatorOptions
     public bool PrintLineNumbers { get; init; }
 
     /// <summary>
-    /// Gets or sets the delimiter which should be used for the CSV export. (default = <c>;</c>).
+    /// Gets or sets the delimiter which should be used for the CSV export (default = <c>;</c>).
     /// </summary>
     /// <remarks>
     /// <b>Note</b>: This value is only needed when the <see cref="OutputType"/> is set to <see cref="OutputType.Csv"/>.
@@ -42,7 +42,7 @@ public sealed class TableCreatorOptions
     public bool AddHeader { get; init; } = true;
 
     /// <summary>
-    /// Gets or sets the value which indicates whether <i>text</i> values should be encapsulated with quotation marks.
+    /// Gets or sets the value which indicates whether <i>text</i> values should be encapsulated with quotation marks (default = <see langword="false"/>).
     /// </summary>
     /// <remarks>
     /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.

--- a/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
+++ b/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
@@ -3,45 +3,54 @@
 namespace ZimLabs.TableCreator.DataObjects;
 
 /// <summary>
-/// Provides the options for the table creation
+/// Provides the options for the table creation.
 /// </summary>
 public sealed class TableCreatorOptions
 {
     /// <summary>
-    /// Gets or sets the desired output type (default = <see cref="OutputType.Default"/>)
+    /// Gets or sets the desired output type (default = <see cref="OutputType.Default"/>).
     /// </summary>
     public OutputType OutputType { get; set; } = OutputType.Default;
 
     /// <summary>
-    /// Gets or sets the value which indicates if a "line number" should be added to the list (default = <see langword="false"/>)
+    /// Gets or sets the value which indicates if a "line number" should be added to the list (default = <see langword="false"/>).
     /// </summary>
     public bool PrintLineNumbers { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the delimiter which should be used for the CSV export. (default = <c>;</c>)
-    /// <para />
-    /// <b>Note</b>: This value is only needed when the <see cref="OutputType"/> is set to <see cref="OutputType.Csv"/>
+    /// Gets or sets the delimiter which should be used for the CSV export. (default = <c>;</c>).
     /// </summary>
+    /// <remarks>
+    /// <b>Note</b>: This value is only needed when the <see cref="OutputType"/> is set to <see cref="OutputType.Csv"/>.
+    /// </remarks>
     public string Delimiter { get; set; } = ";";
 
     /// <summary>
-    /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>)
-    /// <para />
-    /// This value is only used in the file export
+    /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>).
     /// </summary>
+    /// <remarks>
+    /// This value is only used in the file export.
+    /// </remarks>
     public Encoding Encoding { get; set; } = Encoding.UTF8;
 
     /// <summary>
-    /// Gets or sets the value which indicates if a header should be added to the CSV content (default = <see langword="true"/>)
-    /// <para />
-    /// <b>Note</b>: This options is only needed for the CSV Export
+    /// Gets or sets the value which indicates if a header should be added to the CSV content (default = <see langword="true"/>).
     /// </summary>
+    /// <remarks>
+    /// <b>Note</b>: This options is only needed for the CSV Export.
+    /// </remarks>
     public bool AddHeader { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the list with the override entries.
-    /// <para />
-    /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored
+    /// Gets or sets the value which indicates whether <i>text</i> values should be encapsulated with quotation marks.
     /// </summary>
+    public bool EncapsulateText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list with the override entries.
+    /// </summary>
+    /// <remarks>
+    /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored.
+    /// </remarks>
     public List<OverrideAttributeEntry> OverrideList { get; set; } = [];
 }

--- a/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
+++ b/ZimLabs.TableCreator/DataObjects/TableCreatorOptions.cs
@@ -10,12 +10,12 @@ public sealed class TableCreatorOptions
     /// <summary>
     /// Gets or sets the desired output type (default = <see cref="OutputType.Default"/>).
     /// </summary>
-    public OutputType OutputType { get; set; } = OutputType.Default;
+    public OutputType OutputType { get; init; } = OutputType.Default;
 
     /// <summary>
     /// Gets or sets the value which indicates if a "line number" should be added to the list (default = <see langword="false"/>).
     /// </summary>
-    public bool PrintLineNumbers { get; set; } = false;
+    public bool PrintLineNumbers { get; init; }
 
     /// <summary>
     /// Gets or sets the delimiter which should be used for the CSV export. (default = <c>;</c>).
@@ -23,7 +23,7 @@ public sealed class TableCreatorOptions
     /// <remarks>
     /// <b>Note</b>: This value is only needed when the <see cref="OutputType"/> is set to <see cref="OutputType.Csv"/>.
     /// </remarks>
-    public string Delimiter { get; set; } = ";";
+    public string Delimiter { get; init; } = ";";
 
     /// <summary>
     /// Gets or sets the desired encoding (default = <see cref="Encoding.UTF8"/>).
@@ -31,7 +31,7 @@ public sealed class TableCreatorOptions
     /// <remarks>
     /// This value is only used in the file export.
     /// </remarks>
-    public Encoding Encoding { get; set; } = Encoding.UTF8;
+    public Encoding Encoding { get; init; } = Encoding.UTF8;
 
     /// <summary>
     /// Gets or sets the value which indicates if a header should be added to the CSV content (default = <see langword="true"/>).
@@ -39,12 +39,15 @@ public sealed class TableCreatorOptions
     /// <remarks>
     /// <b>Note</b>: This options is only needed for the CSV Export.
     /// </remarks>
-    public bool AddHeader { get; set; } = true;
+    public bool AddHeader { get; init; } = true;
 
     /// <summary>
     /// Gets or sets the value which indicates whether <i>text</i> values should be encapsulated with quotation marks.
     /// </summary>
-    public bool EncapsulateText { get; set; }
+    /// <remarks>
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
+    /// </remarks>
+    public bool EncapsulateText { get; init; }
 
     /// <summary>
     /// Gets or sets the list with the override entries.
@@ -52,5 +55,5 @@ public sealed class TableCreatorOptions
     /// <remarks>
     /// <b>Note</b>: If you add an entry, the original <see cref="AppearanceAttribute"/> of the desired property will be ignored.
     /// </remarks>
-    public List<OverrideAttributeEntry> OverrideList { get; set; } = [];
+    public List<OverrideAttributeEntry> OverrideList { get; init; } = [];
 }

--- a/ZimLabs.TableCreator/TableCreator.cs
+++ b/ZimLabs.TableCreator/TableCreator.cs
@@ -46,7 +46,7 @@ public static class TableCreator
         var count = 1;
         printList.AddRange(list.Select(entry => new LineEntry(count++)
         {
-            Values = properties.Select(s => new ValueEntry(s.Name, TableHelper.GetPropertyValue(entry, s, false)))
+            Values = properties.Select(s => new ValueEntry(s.Name, TableHelper.GetPropertyValue(entry, s, false, options.EncapsulateText)))
                 .ToList()
         }));
 
@@ -73,11 +73,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored.</param>
     /// <returns>The created table.</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'CreateTable<T>(this IEnumerable<T> list, TableCreatorOptions options)' method instead.", false)]
     public static string CreateTable<T>(this IEnumerable<T> list, OutputType outputType = OutputType.Default,
         bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null)
@@ -107,7 +108,7 @@ public static class TableCreator
     {
         var result = CreateTable(list, options);
 
-        File.WriteAllText(filepath, result);
+        File.WriteAllText(filepath, result, options.Encoding);
     }
 
     /// <summary>
@@ -123,11 +124,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored.</param>
     /// <returns>The created table.</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTable<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static void SaveTable<T>(this IEnumerable<T> list, string filepath,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -135,7 +137,6 @@ public static class TableCreator
     {
         list.SaveTable(filepath, new TableCreatorOptions
         {
-            Encoding = Encoding.UTF8,
             OutputType = outputType,
             PrintLineNumbers = printLineNumbers,
             Delimiter = delimiter,
@@ -159,11 +160,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored.</param>
     /// <returns>The created table.</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTable<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static void SaveTable<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -195,7 +197,7 @@ public static class TableCreator
     {
         var result = CreateTable(list, options);
 
-        await File.WriteAllTextAsync(filepath, result);
+        await File.WriteAllTextAsync(filepath, result, options.Encoding);
     }
 
     /// <summary>
@@ -211,11 +213,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTableAsync<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static async Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -246,11 +249,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTableAsync<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static async Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -258,6 +262,7 @@ public static class TableCreator
     {
         await list.SaveTableAsync(filepath, new TableCreatorOptions
         {
+            Encoding = encoding,
             OutputType = outputType,
             PrintLineNumbers = printLineNumbers,
             Delimiter = delimiter,
@@ -331,11 +336,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'CreateTable(this DataTable table, TableCreatorOptions options)' method instead.", false)]
     public static string CreateTable(this DataTable table, OutputType outputType = OutputType.Default,
         bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null)
@@ -376,11 +382,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTable(this DataTable table, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static void SaveTable(this DataTable table, string filepath, OutputType outputType = OutputType.Default,
         bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null)
@@ -409,11 +416,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTable(this DataTable table, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static void SaveTable(this DataTable table, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -457,6 +465,7 @@ public static class TableCreator
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTableAsync(this DataTable table, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static async Task SaveTableAsync(this DataTable table, string filepath,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
@@ -485,6 +494,7 @@ public static class TableCreator
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveTableAsync(this DataTable table, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static async Task SaveTableAsync(this DataTable table, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
@@ -515,7 +525,31 @@ public static class TableCreator
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static string CreateValueList<T>(this T value, TableCreatorListOptions options) where T : class
     {
-        return CreateValueList(value, options.ListType, options.AlignProperties, options.OverrideList);
+        if (TableHelper.IsList<T>())
+        {
+            throw new NotSupportedException(
+                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
+        }
+
+        ArgumentNullException.ThrowIfNull(value);
+
+        // Get the properties
+        var properties = TableHelper.GetProperties<T>(options.OverrideList);
+        var maxLength = properties.Select(s => s.CustomName).Max(m => m.Length);
+
+        var sb = new StringBuilder();
+
+        var count = 1;
+        foreach (var property in properties)
+        {
+            var listIndicator = options.ListType == ListType.Bullets ? "-" : $"{count++}.";
+            var dotLength = options.AlignProperties ? maxLength - property.CustomName.Length : 0;
+            sb.AppendLine(
+                $"{listIndicator} {property.CustomName}{"".PadRight(dotLength, '.')}: " +
+                $"{TableHelper.GetPropertyValue(value, property, false, false)}");
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>
@@ -529,35 +563,17 @@ public static class TableCreator
     /// <returns>The list</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'CreateValueList<T>(this T value, TableCreatorListOptions options)' method instead.", false)]
     public static string CreateValueList<T>(this T value, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        if (TableHelper.IsList<T>())
+        return value.CreateValueList(new TableCreatorListOptions
         {
-            throw new NotSupportedException(
-                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
-        }
-
-        ArgumentNullException.ThrowIfNull(value);
-
-        // Get the properties
-        var properties = TableHelper.GetProperties<T>(overrideList);
-        var maxLength = properties.Select(s => s.CustomName).Max(m => m.Length);
-
-        var sb = new StringBuilder();
-
-        var count = 1;
-        foreach (var property in properties)
-        {
-            var listIndicator = type == ListType.Bullets ? "-" : $"{count++}.";
-            var dotLength = alignProperties ? maxLength - property.CustomName.Length : 0;
-            sb.AppendLine(
-                $"{listIndicator} {property.CustomName}{"".PadRight(dotLength, '.')}: " +
-                $"{TableHelper.GetPropertyValue(value, property, false)}");
-        }
-
-        return sb.ToString();
+            ListType = type,
+            AlignProperties = alignProperties,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -582,7 +598,7 @@ public static class TableCreator
         var properties = TableHelper.GetProperties<T>(options.OverrideList);
 
         var data = (from property in properties
-            let tmpValue = TableHelper.GetPropertyValue(value, property, options.OutputType == OutputType.Csv)
+            let tmpValue = TableHelper.GetPropertyValue(value, property, options.OutputType == OutputType.Csv, options.EncapsulateText)
             select new KeyValueEntry(property.CustomName, tmpValue)).ToList();
 
         return CreateTable(data, options);
@@ -600,12 +616,13 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'CreateValueTable<T>(this T value, TableCreatorOptions options)' method instead.", false)]
     public static string CreateValueTable<T>(this T value, OutputType outputType = OutputType.Default,
         bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null) where T : class
@@ -627,18 +644,38 @@ public static class TableCreator
     /// <typeparam name="T">The type of the value</typeparam>
     /// <param name="value">The value</param>
     /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the list creation</param>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    public static void SaveValue<T>(this T value, string filepath, TableCreatorListOptions options) where T : class
+    {
+        var result = value.CreateValueList(options);
+
+        File.WriteAllText(filepath, result, options.Encoding);
+    }
+
+    /// <summary>
+    /// Creates a list of the properties with its values and saves it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
     /// <param name="type">The desired list type</param>
     /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValue<T>(this T value, string filepath, TableCreatorListOptions options)' method instead.", false)]
     public static void SaveValue<T>(this T value, string filepath, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        var result = value.CreateValueList(type, alignProperties, overrideList);
-
-        File.WriteAllText(filepath, result, Encoding.UTF8);
+        value.SaveValue(filepath, new TableCreatorListOptions
+        {
+            ListType = type,
+            AlignProperties = alignProperties,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -653,27 +690,18 @@ public static class TableCreator
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValue<T>(this T value, string filepath, TableCreatorListOptions options)' method instead.", false)]
     public static void SaveValue<T>(this T value, string filepath, Encoding encoding, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        var result = value.CreateValueList(type, alignProperties, overrideList);
-
-        File.WriteAllText(filepath, result, encoding);
-    }
-
-    /// <summary>
-    /// Creates a list of the properties with its values and saves it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the value</typeparam>
-    /// <param name="value">The value</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the list creation</param>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    public static void SaveValue<T>(this T value, string filepath, TableCreatorListOptions options) where T : class
-    {
-        SaveValue(value, filepath, options.Encoding, options.ListType, options.AlignProperties, options.OverrideList);
+        value.SaveValue(filepath, new TableCreatorListOptions
+        {
+            Encoding = encoding,
+            ListType = type,
+            AlignProperties = alignProperties,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -700,7 +728,7 @@ public static class TableCreator
         var data = properties.Select(s => new
         {
             Key = s.CustomName,
-            Value = TableHelper.GetPropertyValue(value, s, options.OutputType == OutputType.Csv)
+            Value = TableHelper.GetPropertyValue(value, s, options.OutputType == OutputType.Csv, options.EncapsulateText)
         });
 
         data.SaveTable(filepath, options);
@@ -719,11 +747,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValueAsTable<T>(this T value, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static void SaveValueAsTable<T>(this T value, string filepath, OutputType outputType = OutputType.Default,
         bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null) where T : class
@@ -754,11 +783,12 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValueAsTable<T>(this T value, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static void SaveValueAsTable<T>(this T value, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null) where T : class
@@ -781,18 +811,39 @@ public static class TableCreator
     /// <typeparam name="T">The type of the value</typeparam>
     /// <param name="value">The value</param>
     /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the list creation</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    public static async Task SaveValueAsync<T>(this T value, string filepath, TableCreatorListOptions options) where T : class
+    {
+        var result = value.CreateValueList(options);
+
+        await File.WriteAllTextAsync(filepath, result, options.Encoding);
+    }
+
+    /// <summary>
+    /// Creates a list of the properties with its values and saves it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
     /// <param name="type">The desired list type</param>
     /// <param name="alignProperties"><see langword="true"/> to add dots to the end of the properties so that all properties have the same length</param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    public static Task SaveValueAsync<T>(this T value, string filepath, ListType type = ListType.Bullets,
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValueAsync<T>(this T value, string filepath, TableCreatorListOptions options)' method instead.", false)]
+    public static async Task SaveValueAsync<T>(this T value, string filepath, ListType type = ListType.Bullets,
         bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null) where T : class
     {
-        var result = value.CreateValueList(type, alignProperties, overrideList);
-
-        return File.WriteAllTextAsync(filepath, result, Encoding.UTF8);
+        await value.SaveValueAsync(filepath, new TableCreatorListOptions
+        {
+            ListType = type,
+            AlignProperties = alignProperties,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -808,29 +859,18 @@ public static class TableCreator
     /// <returns>The awaitable task</returns>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    public static Task SaveValueAsync<T>(this T value, string filepath, Encoding encoding,
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValueAsync<T>(this T value, string filepath, TableCreatorListOptions options)' method instead.", false)]
+    public static async Task SaveValueAsync<T>(this T value, string filepath, Encoding encoding,
         ListType type = ListType.Bullets, bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        var result = value.CreateValueList(type, alignProperties, overrideList);
-
-        return File.WriteAllTextAsync(filepath, result, encoding);
-    }
-
-    /// <summary>
-    /// Creates a list of the properties with its values and saves it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the value</typeparam>
-    /// <param name="value">The value</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the list creation</param>
-    /// <returns>The awaitable task</returns>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    public static Task SaveValueAsync<T>(this T value, string filepath, TableCreatorListOptions options) where T : class
-    {
-        return SaveValueAsync(value, filepath, options.Encoding, options.ListType, options.AlignProperties,
-            options.OverrideList);
+        await value.SaveValueAsync(filepath, new TableCreatorListOptions
+        {
+            Encoding = encoding,
+            ListType = type,
+            AlignProperties = alignProperties,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -859,7 +899,7 @@ public static class TableCreator
         var data = properties.Select(s => new
         {
             Key = s.CustomName,
-            Value = TableHelper.GetPropertyValue(value, s, options.OutputType == OutputType.Csv)
+            Value = TableHelper.GetPropertyValue(value, s, options.OutputType == OutputType.Csv, options.EncapsulateText)
         });
 
         await data.SaveTableAsync(filepath, options);
@@ -878,12 +918,13 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValueAsTableAsync<T>(this T value, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static async Task SaveValueAsTableAsync<T>(this T value, string filepath,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
@@ -915,12 +956,13 @@ public static class TableCreator
     /// <param name="encapsulateText">
     /// The value which indicates whether text values should be encapsulated with quotation marks.
     /// <para />
-    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the attribute is ignored on the respective property for <i>text</i> fields.
     /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    [Obsolete("To keep the code clearer, this method will be removed in the next version. Please use the 'SaveValueAsTableAsync<T>(this T value, string filepath, TableCreatorOptions options)' method instead.", false)]
     public static async Task SaveValueAsTableAsync<T>(this T value, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)

--- a/ZimLabs.TableCreator/TableCreator.cs
+++ b/ZimLabs.TableCreator/TableCreator.cs
@@ -12,29 +12,23 @@ public static class TableCreator
     #region Public methods for lists
 
     /// <summary>
-    /// Converts the given list into a "table"
+    /// Converts the given list into a "table" or a CSV list.
     /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <param name="list">The list with the values</param>
-    /// <param name="outputType">The desired output type (optional)</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
-    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
+    /// <typeparam name="T">The type of the values.</typeparam>
+    /// <param name="list">The list with the values.</param>
+    /// <param name="options">The options for the creation of the table</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static string CreateTable<T>(this IEnumerable<T> list, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
-        where T : class
+    public static string CreateTable<T>(this IEnumerable<T> list, TableCreatorOptions options) where T : class
     {
         // Check if the list is "null"
         ArgumentNullException.ThrowIfNull(list);
 
-        if (outputType == OutputType.Csv)
-            return TableHelper.CreateCsv(list, delimiter, printLineNumbers, addHeader, overrideList);
+        if (options.OutputType == OutputType.Csv)
+            return TableHelper.CreateCsv(list, options);
 
         // Get the properties of the given type
-        var properties = TableHelper.GetProperties<T>(overrideList);
+        var properties = TableHelper.GetProperties<T>(options.OverrideList);
 
         // Create the temp list
         var printList = new List<LineEntry>();
@@ -45,14 +39,15 @@ public static class TableCreator
             // Add the columns to the header
             Values = properties.Select(s => new ValueEntry(s)).ToList()
         };
-        
+
         printList.Add(headerLine);
 
         // Add the values to the list
         var count = 1;
         printList.AddRange(list.Select(entry => new LineEntry(count++)
         {
-            Values = properties.Select(s => new ValueEntry(s.Name, TableHelper.GetPropertyValue(entry, s, false))).ToList()
+            Values = properties.Select(s => new ValueEntry(s.Name, TableHelper.GetPropertyValue(entry, s, false)))
+                .ToList()
         }));
 
         // 3 = "Row"
@@ -62,77 +57,145 @@ public static class TableCreator
         // Get the max values
         var widthList = TableHelper.GetColumnWidthList(properties, printList);
 
-        return TableHelper.CreateTable(outputType, printLineNumbers, maxLineLength, widthList, printList);
+        return TableHelper.CreateTable(options.OutputType, options.PrintLineNumbers, maxLineLength, widthList,
+            printList);
     }
 
     /// <summary>
-    /// Converts the given list into a "table"
+    /// Converts the given list into a "table" or a CSV list.
     /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
+    /// <typeparam name="T">The type of the values.</typeparam>
     /// <param name="list">The list with the values</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <returns>The created table</returns>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static string CreateTable<T>(this IEnumerable<T> list, TableCreatorOptions options) where T : class
-    {
-        return CreateTable(list, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader, options.OverrideList);
-    }
-
-    /// <summary>
-    /// Converts the given list into a "table" and save it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <param name="list">The list with the values</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="outputType">The desired output type (optional)</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
-    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static void SaveTable<T>(this IEnumerable<T> list, string filepath,
-        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
-        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
+    /// <param name="outputType">The desired output type.</param>
+    /// <param name="printLineNumbers"><see langword="true"/> to print line numbers, otherwise <see langword="false"/>.</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>).</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>.</param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
+    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored.</param>
+    /// <returns>The created table.</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
+    public static string CreateTable<T>(this IEnumerable<T> list, OutputType outputType = OutputType.Default,
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
+        List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        list.SaveTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader, overrideList);
+        return CreateTable(list, new TableCreatorOptions
+        {
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
     /// Converts the given list into a "table" and save it into the specified file
     /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <param name="list">The list with the values</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="encoding">The encoding of the file</param>
-    /// <param name="outputType">The desired output type (optional)</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
-    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static void SaveTable<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
-        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
-        where T : class
-    {
-        var result = CreateTable(list, outputType, printLineNumbers, delimiter, addHeader, overrideList);
-
-        File.WriteAllText(filepath, result, encoding);
-    }
-
-    /// <summary>
-    /// Converts the given list into a "table" and save it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <param name="list">The list with the values</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    /// <typeparam name="T">The type of the values.</typeparam>
+    /// <param name="list">The list with the values.</param>
+    /// <param name="filepath">The path of the destination file.</param>
+    /// <param name="options">The options for the creation of the table.</param>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
     public static void SaveTable<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)
         where T : class
     {
-        SaveTable(list, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader, options.OverrideList);
+        var result = CreateTable(list, options);
+
+        File.WriteAllText(filepath, result);
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="list">The list with the values</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="outputType">The desired output type.</param>
+    /// <param name="printLineNumbers"><see langword="true"/> to print line numbers, otherwise <see langword="false"/>.</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>).</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>.</param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
+    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored.</param>
+    /// <returns>The created table.</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
+    public static void SaveTable<T>(this IEnumerable<T> list, string filepath,
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
+        where T : class
+    {
+        list.SaveTable(filepath, new TableCreatorOptions
+        {
+            Encoding = Encoding.UTF8,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="list">The list with the values</param>
+    /// <param name="filepath">The path of the destination file.</param>
+    /// <param name="encoding">The encoding of the file.</param>
+    /// <param name="outputType">The desired output type.</param>
+    /// <param name="printLineNumbers"><see langword="true"/> to print line numbers, otherwise <see langword="false"/>.</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>).</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>.</param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
+    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored.</param>
+    /// <returns>The created table.</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/>.</exception>
+    public static void SaveTable<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
+        where T : class
+    {
+        list.SaveTable(filepath, new TableCreatorOptions
+        {
+            Encoding = encoding,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <param name="list">The list with the values</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static async Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)
+        where T : class
+    {
+        var result = CreateTable(list, options);
+
+        await File.WriteAllTextAsync(filepath, result);
     }
 
     /// <summary>
@@ -145,16 +208,28 @@ public static class TableCreator
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath,
+    public static async Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
-        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        return list.SaveTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader,
-            overrideList);
+        await list.SaveTableAsync(filepath, new TableCreatorOptions
+        {
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -168,31 +243,28 @@ public static class TableCreator
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, Encoding encoding, OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
+    public static async Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, Encoding encoding,
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        var result = CreateTable(list, outputType, printLineNumbers, delimiter, addHeader, overrideList);
-
-        return File.WriteAllTextAsync(filepath, result, encoding);
-    }
-
-    /// <summary>
-    /// Converts the given list into a "table" and save it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <param name="list">The list with the values</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <returns>The awaitable task</returns>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync<T>(this IEnumerable<T> list, string filepath, TableCreatorOptions options)
-        where T : class
-    {
-        return SaveTableAsync(list, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
-            options.Delimiter, options.AddHeader, options.OverrideList);
+        await list.SaveTableAsync(filepath, new TableCreatorOptions
+        {
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     #endregion
@@ -203,23 +275,18 @@ public static class TableCreator
     /// Converts the given list into a "table"
     /// </summary>
     /// <param name="table">The table with the data</param>
-    /// <param name="outputType">The desired output type (optional)</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
-    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
+    /// <param name="options">The options for the creation of the table</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static string CreateTable(this DataTable table, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
+    public static string CreateTable(this DataTable table, TableCreatorOptions options)
     {
         ArgumentNullException.ThrowIfNull(table);
 
-        if (outputType == OutputType.Csv)
-            return TableHelper.CreateCsv(table, delimiter, printLineNumbers, addHeader, overrideList);
+        if (options.OutputType == OutputType.Csv)
+            return TableHelper.CreateCsv(table, options);
 
         // Get the properties of the given type
-        var properties = TableHelper.GetProperties(table, overrideList);
+        var properties = TableHelper.GetProperties(table, options.OverrideList);
 
         // Create the temp list
         var printList = new List<LineEntry>();
@@ -239,7 +306,8 @@ public static class TableCreator
             select new LineEntry(count++)
             {
                 Values = properties.Select(s =>
-                    new ValueEntry(s.Name, TableHelper.GetPropertyValue(row, s.Name, s.Appearance.Format, false))).ToList()
+                        new ValueEntry(s.Name, TableHelper.GetPropertyValue(row, s.Name, s.Appearance.Format, false)))
+                    .ToList()
             });
 
         // 3 chars for "row"
@@ -248,59 +316,39 @@ public static class TableCreator
         // Get the max values
         var widthList = TableHelper.GetColumnWidthList(properties, printList);
 
-        return TableHelper.CreateTable(outputType, printLineNumbers, maxLineLength, widthList, printList);
+        return TableHelper.CreateTable(options.OutputType, options.PrintLineNumbers, maxLineLength, widthList,
+            printList);
     }
 
     /// <summary>
     /// Converts the given list into a "table"
     /// </summary>
     /// <param name="table">The table with the data</param>
-    /// <param name="options">The options for the creation of the table</param>
+    /// <param name="outputType">The desired output type (optional)</param>
+    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
+    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static string CreateTable(this DataTable table, TableCreatorOptions options)
-    {
-        return CreateTable(table, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader,
-            options.OverrideList);
-    }
-
-    /// <summary>
-    /// Converts the given list into a "table" and save it into the specified file
-    /// </summary>
-    /// <param name="table">The table with the data</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="outputType">The desired output type (optional)</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
-    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static void SaveTable(this DataTable table, string filepath, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true,
+    public static string CreateTable(this DataTable table, OutputType outputType = OutputType.Default,
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null)
     {
-        table.SaveTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader, overrideList);
-    }
-
-    /// <summary>
-    /// Converts the given list into a "table" and save it into the specified file
-    /// </summary>
-    /// <param name="table">The table with the data</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="encoding">The encoding of the file</param>
-    /// <param name="outputType">The desired output type (optional)</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
-    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static void SaveTable(this DataTable table, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
-        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
-    {
-        var result = CreateTable(table, outputType, printLineNumbers, delimiter, addHeader, overrideList);
-
-        File.WriteAllText(filepath, result, encoding);
+        return table.CreateTable(new TableCreatorOptions
+        {
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -312,8 +360,89 @@ public static class TableCreator
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
     public static void SaveTable(this DataTable table, string filepath, TableCreatorOptions options)
     {
-        SaveTable(table, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers, options.Delimiter,
-            options.AddHeader, options.OverrideList);
+        var result = CreateTable(table, options);
+
+        File.WriteAllText(filepath, result, options.Encoding);
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <param name="table">The table with the data</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="outputType">The desired output type (optional)</param>
+    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static void SaveTable(this DataTable table, string filepath, OutputType outputType = OutputType.Default,
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
+        List<OverrideAttributeEntry>? overrideList = null)
+    {
+        table.SaveTable(filepath, new TableCreatorOptions
+        {
+            Encoding = Encoding.UTF8,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <param name="table">The table with the data</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="encoding">The encoding of the file</param>
+    /// <param name="outputType">The desired output type (optional)</param>
+    /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static void SaveTable(this DataTable table, string filepath, Encoding encoding,
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
+    {
+        table.SaveTable(filepath, new TableCreatorOptions
+        {
+            Encoding = encoding,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
+    }
+
+    /// <summary>
+    /// Converts the given list into a "table" and save it into the specified file
+    /// </summary>
+    /// <param name="table">The table with the data</param>
+    /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
+    public static async Task SaveTableAsync(this DataTable table, string filepath, TableCreatorOptions options)
+    {
+        var result = CreateTable(table, options);
+
+        await File.WriteAllTextAsync(filepath, result, options.Encoding);
     }
 
     /// <summary>
@@ -328,12 +457,19 @@ public static class TableCreator
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync(this DataTable table, string filepath, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true,
-        List<OverrideAttributeEntry>? overrideList = null)
+    public static async Task SaveTableAsync(this DataTable table, string filepath,
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
-        return table.SaveTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader,
-            overrideList);
+        await table.SaveTableAsync(filepath, new TableCreatorOptions
+        {
+            Encoding = Encoding.UTF8,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -349,32 +485,38 @@ public static class TableCreator
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync(this DataTable table, string filepath, Encoding encoding,
+    public static async Task SaveTableAsync(this DataTable table, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
         bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
     {
-        var result = CreateTable(table, outputType, printLineNumbers, delimiter, addHeader, overrideList);
-
-        return File.WriteAllTextAsync(filepath, result, encoding);
-    }
-
-    /// <summary>
-    /// Converts the given list into a "table" and save it into the specified file
-    /// </summary>
-    /// <param name="table">The table with the data</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <returns>The awaitable task</returns>
-    /// <exception cref="ArgumentNullException">Will be thrown if the provided list is <see langword="null"/></exception>
-    public static Task SaveTableAsync(this DataTable table, string filepath, TableCreatorOptions options)
-    {
-        return SaveTableAsync(table, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
-            options.Delimiter, options.AddHeader, options.OverrideList);
+        await table.SaveTableAsync(filepath, new TableCreatorOptions
+        {
+            Encoding = encoding,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            OverrideList = overrideList ?? []
+        });
     }
 
     #endregion
 
     #region Public methods for objects
+
+    /// <summary>
+    /// Creates a list of the properties with its values
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="options">The options for the list creation</param>
+    /// <returns>The list</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static string CreateValueList<T>(this T value, TableCreatorListOptions options) where T : class
+    {
+        return CreateValueList(value, options.ListType, options.AlignProperties, options.OverrideList);
+    }
 
     /// <summary>
     /// Creates a list of the properties with its values
@@ -388,7 +530,7 @@ public static class TableCreator
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static string CreateValueList<T>(this T value, ListType type = ListType.Bullets,
-        bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null) 
+        bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
         if (TableHelper.IsList<T>())
@@ -419,17 +561,31 @@ public static class TableCreator
     }
 
     /// <summary>
-    /// Creates a list of the properties with its values
+    /// Converts the given value into a "table" (Key, Value columns)
     /// </summary>
-    /// <typeparam name="T">The type of the value</typeparam>
+    /// <typeparam name="T">The type of the values</typeparam>
     /// <param name="value">The value</param>
-    /// <param name="options">The options for the list creation</param>
-    /// <returns>The list</returns>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    public static string CreateValueList<T>(this T value, TableCreatorListOptions options) where T : class
+    public static string CreateValueTable<T>(this T value, TableCreatorOptions options) where T : class
     {
-        return CreateValueList(value, options.ListType, options.AlignProperties, options.OverrideList);
+        if (TableHelper.IsList<T>())
+        {
+            throw new NotSupportedException(
+                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
+        }
+
+        ArgumentNullException.ThrowIfNull(value);
+
+        var properties = TableHelper.GetProperties<T>(options.OverrideList);
+
+        var data = (from property in properties
+            let tmpValue = TableHelper.GetPropertyValue(value, property, options.OutputType == OutputType.Csv)
+            select new KeyValueEntry(property.CustomName, tmpValue)).ToList();
+
+        return CreateTable(data, options);
     }
 
     /// <summary>
@@ -441,43 +597,28 @@ public static class TableCreator
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The created table</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static string CreateValueTable<T>(this T value, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true,
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
         List<OverrideAttributeEntry>? overrideList = null) where T : class
     {
-        if (TableHelper.IsList<T>())
+        return value.CreateValueTable(new TableCreatorOptions
         {
-            throw new NotSupportedException(
-                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
-        }
-
-        ArgumentNullException.ThrowIfNull(value);
-
-        var properties = TableHelper.GetProperties<T>(overrideList);
-
-        var data = (from property in properties
-            let tmpValue = TableHelper.GetPropertyValue(value, property, outputType == OutputType.Csv)
-            select new KeyValueEntry(property.CustomName, tmpValue)).ToList();
-
-        return CreateTable(data, outputType, printLineNumbers, delimiter, addHeader, overrideList);
-    }
-
-    /// <summary>
-    /// Converts the given value into a "table" (Key, Value columns)
-    /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <param name="value">The value</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <returns>The created table</returns>
-    /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    public static string CreateValueTable<T>(this T value, TableCreatorOptions options) where T : class
-    {
-        return CreateValueTable(value, options.OutputType, options.PrintLineNumbers, options.Delimiter, options.AddHeader, options.OverrideList);
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -541,20 +682,62 @@ public static class TableCreator
     /// <typeparam name="T">The type of the value</typeparam>
     /// <param name="value">The value</param>
     /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static void SaveValueAsTable<T>(this T value, string filepath, TableCreatorOptions options) where T : class
+    {
+        if (TableHelper.IsList<T>())
+        {
+            throw new NotSupportedException(
+                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
+        }
+
+        ArgumentNullException.ThrowIfNull(value);
+
+        var properties = TableHelper.GetProperties<T>(options.OverrideList);
+
+        var data = properties.Select(s => new
+        {
+            Key = s.CustomName,
+            Value = TableHelper.GetPropertyValue(value, s, options.OutputType == OutputType.Csv)
+        });
+
+        data.SaveTable(filepath, options);
+    }
+
+    /// <summary>
+    /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static void SaveValueAsTable<T>(this T value, string filepath, OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
-        where T : class
+        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, bool encapsulateText = false,
+        List<OverrideAttributeEntry>? overrideList = null) where T : class
     {
-        ArgumentNullException.ThrowIfNull(value);
-
-        value.SaveValueAsTable(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader, overrideList);
+        value.SaveValueAsTable(filepath, new TableCreatorOptions
+        {
+            Encoding = Encoding.UTF8,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -568,45 +751,28 @@ public static class TableCreator
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     public static void SaveValueAsTable<T>(this T value, string filepath, Encoding encoding,
-        OutputType outputType = OutputType.Default,
-        bool printLineNumbers = false, string delimiter = ";", bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
+        OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null) where T : class
     {
-        if (TableHelper.IsList<T>())
+        value.SaveValueAsTable(filepath, new TableCreatorOptions
         {
-            throw new NotSupportedException(
-                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
-        }
-
-        ArgumentNullException.ThrowIfNull(value);
-
-        var properties = TableHelper.GetProperties<T>(overrideList);
-
-        var data = properties.Select(s => new
-        {
-            Key = s.CustomName,
-            Value = TableHelper.GetPropertyValue(value, s, outputType == OutputType.Csv)
+            Encoding = encoding,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
         });
-
-        data.SaveTable(filepath, encoding, outputType, printLineNumbers, delimiter, addHeader);
-    }
-
-    /// <summary>
-    /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the value</typeparam>
-    /// <param name="value">The value</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    public static void SaveValueAsTable<T>(this T value, string filepath, TableCreatorOptions options) where T : class
-    {
-        SaveValueAsTable(value, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
-            options.Delimiter, options.AddHeader, options.OverrideList);
     }
 
     /// <summary>
@@ -622,8 +788,7 @@ public static class TableCreator
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
     public static Task SaveValueAsync<T>(this T value, string filepath, ListType type = ListType.Bullets,
-        bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
-        where T : class
+        bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null) where T : class
     {
         var result = value.CreateValueList(type, alignProperties, overrideList);
 
@@ -643,8 +808,8 @@ public static class TableCreator
     /// <returns>The awaitable task</returns>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
     /// <exception cref="ArgumentNullException">Will be thrown when the value is null</exception>
-    public static Task SaveValueAsync<T>(this T value, string filepath, Encoding encoding, ListType type = ListType.Bullets,
-        bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
+    public static Task SaveValueAsync<T>(this T value, string filepath, Encoding encoding,
+        ListType type = ListType.Bullets, bool alignProperties = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
         var result = value.CreateValueList(type, alignProperties, overrideList);
@@ -674,23 +839,66 @@ public static class TableCreator
     /// <typeparam name="T">The type of the value</typeparam>
     /// <param name="value">The value</param>
     /// <param name="filepath">The path of the destination file</param>
+    /// <param name="options">The options for the creation of the table</param>
+    /// <returns>The awaitable task</returns>
+    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
+    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
+    public static async Task SaveValueAsTableAsync<T>(this T value, string filepath, TableCreatorOptions options)
+        where T : class
+    {
+        if (TableHelper.IsList<T>())
+        {
+            throw new NotSupportedException(
+                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
+        }
+
+        ArgumentNullException.ThrowIfNull(value);
+
+        var properties = TableHelper.GetProperties<T>(options.OverrideList);
+
+        var data = properties.Select(s => new
+        {
+            Key = s.CustomName,
+            Value = TableHelper.GetPropertyValue(value, s, options.OutputType == OutputType.Csv)
+        });
+
+        await data.SaveTableAsync(filepath, options);
+    }
+
+    /// <summary>
+    /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="value">The value</param>
+    /// <param name="filepath">The path of the destination file</param>
     /// <param name="outputType">The desired output type (optional)</param>
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    public static Task SaveValueAsTableAsync<T>(this T value, string filepath,
+    public static async Task SaveValueAsTableAsync<T>(this T value, string filepath,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
-        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        ArgumentNullException.ThrowIfNull(value);
-
-        return value.SaveValueAsTableAsync(filepath, Encoding.UTF8, outputType, printLineNumbers, delimiter, addHeader,
-            overrideList);
+        await value.SaveValueAsTableAsync(filepath, new TableCreatorOptions
+        {
+            Encoding = Encoding.UTF8,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     /// <summary>
@@ -704,48 +912,30 @@ public static class TableCreator
     /// <param name="printLineNumbers">true to print line numbers, otherwise false (optional)</param>
     /// <param name="delimiter">The delimiter which should be used for CSV (only needed when <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/>)</param>
     /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>. This value is only used when the <paramref name="outputType"/> is set to <see cref="OutputType.Csv"/></param>
+    /// <param name="encapsulateText">
+    /// The value which indicates whether text values should be encapsulated with quotation marks.
+    /// <para />
+    /// <b>Note</b>: If this value is set to <see langword="true"/>, the property is ignored on the respective property for <i>text</i> fields.
+    /// </param>
     /// <param name="overrideList">The list with the override entries (optional). If you add an entry, the original <see cref="AppearanceAttribute"/> will be ignored</param>
     /// <returns>The awaitable task</returns>
     /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
     /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    public static Task SaveValueAsTableAsync<T>(this T value, string filepath, Encoding encoding,
+    public static async Task SaveValueAsTableAsync<T>(this T value, string filepath, Encoding encoding,
         OutputType outputType = OutputType.Default, bool printLineNumbers = false, string delimiter = ";",
-        bool addHeader = true, List<OverrideAttributeEntry>? overrideList = null)
-    {
-        if (TableHelper.IsList<T>())
-        {
-            throw new NotSupportedException(
-                "The specified type is not supported by this method. Please choose \"CreateTable\" or \"SaveTable\" instead.");
-        }
-
-        ArgumentNullException.ThrowIfNull(value);
-
-        var properties = TableHelper.GetProperties<T>(overrideList);
-
-        var data = properties.Select(s => new
-        {
-            Key = s.CustomName,
-            Value = TableHelper.GetPropertyValue(value, s, outputType == OutputType.Csv)
-        });
-
-        return data.SaveTableAsync(filepath, encoding, outputType, printLineNumbers, delimiter, addHeader);
-    }
-
-    /// <summary>
-    /// Converts the given value into a "table" (Key, Value column) and save it into the specified file
-    /// </summary>
-    /// <typeparam name="T">The type of the value</typeparam>
-    /// <param name="value">The value</param>
-    /// <param name="filepath">The path of the destination file</param>
-    /// <param name="options">The options for the creation of the table</param>
-    /// <returns>The awaitable task</returns>
-    /// <exception cref="ArgumentNullException">Will be thrown when the specified value is null</exception>
-    /// <exception cref="NotSupportedException">Will be thrown when the specified type is assignable from IEnumerable</exception>
-    public static Task SaveValueAsTableAsync<T>(this T value, string filepath, TableCreatorOptions options)
+        bool addHeader = true, bool encapsulateText = false, List<OverrideAttributeEntry>? overrideList = null)
         where T : class
     {
-        return SaveValueAsTableAsync(value, filepath, options.Encoding, options.OutputType, options.PrintLineNumbers,
-            options.Delimiter, options.AddHeader, options.OverrideList);
+        await value.SaveValueAsTableAsync(filepath, new TableCreatorOptions
+        {
+            Encoding = encoding,
+            OutputType = outputType,
+            PrintLineNumbers = printLineNumbers,
+            Delimiter = delimiter,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
     }
 
     #endregion

--- a/ZimLabs.TableCreator/TableHelper.cs
+++ b/ZimLabs.TableCreator/TableHelper.cs
@@ -52,57 +52,79 @@ internal static class TableHelper
     }
 
     /// <summary>
-    /// Creates a CSV formatted string of the list
+    /// Creates a CSV formatted string of the value list.
     /// </summary>
-    /// <typeparam name="T">The type</typeparam>
-    /// <param name="list">The list with the values</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/></param>
-    /// <param name="overrideList">The list with the override entries</param>
-    /// <returns>The csv file content</returns>
-    public static string CreateCsv<T>(IEnumerable<T> list, string delimiter, bool printLineNumbers, bool addHeader,
+    /// <typeparam name="T">The type of the data.</typeparam>
+    /// <param name="list">The list with the values.</param>
+    /// <param name="delimiter">The delimiter which should be used for CSV.</param>
+    /// <param name="printLineNumbers"><see langword="true"/> to print line numbers, otherwise <see langword="false"/>.</param>
+    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/>.</param>
+    /// <param name="encapsulateText">The value which indicates whether text values should be encapsulated with quotation marks.</param>
+    /// <param name="overrideList">The list with the override entries.</param>
+    /// <returns>The csv file content.</returns>
+    public static string CreateCsv<T>(IEnumerable<T> list, string delimiter, bool printLineNumbers, bool addHeader, bool encapsulateText,
         List<OverrideAttributeEntry>? overrideList)
     {
+        return CreateCsv(list, new TableCreatorOptions
+        {
+            Delimiter = delimiter,
+            PrintLineNumbers = printLineNumbers,
+            AddHeader = addHeader,
+            EncapsulateText = encapsulateText,
+            OverrideList = overrideList ?? []
+        });
+    }
+
+    /// <summary>
+    /// Creates a CSV formatted string of the value list.
+    /// </summary>
+    /// <typeparam name="T">The type of the data.</typeparam>
+    /// <param name="list">The list which contains the values.</param>
+    /// <param name="options">The desired options like the delimiter.</param>
+    /// <returns>The CSV file content.</returns>
+    public static string CreateCsv<T>(IEnumerable<T> list, TableCreatorOptions options)
+    {
+        // Remove all possible "null" values
         var tmpList = list.Where(w => w != null).ToList();
 
         if (tmpList.Count == 0)
-            return string.Empty;
+            return string.Empty; // Return an empty string.
 
+        // Prepare the result
         var content = new StringBuilder();
 
         // Get the properties
-        var properties = GetProperties<T>(overrideList);
+        var properties = GetProperties<T>(options.OverrideList);
 
-        // Add header line
-        if (addHeader)
+        // Add the header (if desired)
+        if (options.AddHeader)
         {
             var headerList = new List<string>();
-            if (printLineNumbers)
+            if (options.PrintLineNumbers)
                 headerList.Add("Row");
 
-            headerList.AddRange(properties.Select(s => string.IsNullOrEmpty(s.Appearance.Name)
-                ? s.Name
-                : s.Appearance.Name));
+            // Add the header
+            headerList.AddRange(properties.Select(s => s.CustomName));
 
-            content.AppendLine(string.Join(delimiter, headerList));
+            // Add the header to the content
+            content.AppendLine(string.Join(options.Delimiter, headerList));
         }
 
         // Add the content
         var rowCount = 1;
-        foreach (var valueList in tmpList.Where(w => w != null).Select(entry => (from property in properties
+        foreach (var values in tmpList.Select(entry => (from property in properties
                      where !property.Appearance.Ignore
-                     select GetPropertyValue(entry!, property, true)).ToList()))
+                     select GetPropertyValue(entry, property, true)).ToList()))
         {
-            if (printLineNumbers)
-                valueList.Insert(0, rowCount.ToString());
+            if (options.PrintLineNumbers)
+                values.Insert(0, rowCount.ToString());
 
-            content.AppendLine(string.Join(delimiter, valueList));
+            content.AppendLine(string.Join(options.Delimiter, values));
 
             rowCount++;
         }
 
-        // Return the result
+        // Return the created content.
         return content.ToString();
     }
 
@@ -110,12 +132,9 @@ internal static class TableHelper
     /// Creates a CSV formatted string of the list
     /// </summary>
     /// <param name="table">The data table</param>
-    /// <param name="delimiter">The delimiter which should be used for CSV</param>
-    /// <param name="printLineNumbers">true to print line numbers, otherwise false</param>
-    /// <param name="addHeader"><see langword="true"/> to add a header, otherwise <see langword="false"/></param>
-    /// <param name="overrideList">The list with the override entries</param>
+    /// <param name="options">The desired options like the delimiter.</param>
     /// <returns>The csv file content</returns>
-    public static string CreateCsv(DataTable table, string delimiter, bool printLineNumbers, bool addHeader, List<OverrideAttributeEntry>? overrideList)
+    public static string CreateCsv(DataTable table, TableCreatorOptions options)
     {
         if (table.Rows.Count == 0)
             return string.Empty;
@@ -123,13 +142,13 @@ internal static class TableHelper
         var content = new StringBuilder();
 
         // Get the properties
-        var properties = GetProperties(table, overrideList);
+        var properties = GetProperties(table, options.OverrideList);
 
         // Add the header line
-        if (addHeader)
+        if (options.AddHeader)
         {
             var headerList = new List<string>();
-            if (printLineNumbers)
+            if (options.PrintLineNumbers)
                 headerList.Add("Row");
 
             headerList.AddRange(properties.Select(s => string.IsNullOrEmpty(s.Appearance.Name)
@@ -137,7 +156,7 @@ internal static class TableHelper
                 : s.Appearance.Name));
 
             // Add the header to the content
-            content.AppendLine(string.Join(delimiter, headerList));
+            content.AppendLine(string.Join(options.Delimiter, headerList));
         }
 
         // Add the content
@@ -146,13 +165,13 @@ internal static class TableHelper
         {
             var valueList = new List<string>();
 
-            if (printLineNumbers)
+            if (options.PrintLineNumbers)
                 valueList.Add(rowCount.ToString());
 
             valueList.AddRange(properties.Select(property => GetPropertyValue(row, property.Name,
                 property.Appearance.Format, property.Appearance.EncapsulateContent)));
 
-            content.AppendLine(string.Join(delimiter, valueList));
+            content.AppendLine(string.Join(options.Delimiter, valueList));
 
             rowCount++;
         }

--- a/ZimLabs.TableCreator/ZimLabs.TableCreator.csproj
+++ b/ZimLabs.TableCreator/ZimLabs.TableCreator.csproj
@@ -1,27 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-      <Authors>Andreas Pouwels</Authors>
-      <Description>Library to convert a list of values into a "table" (ASCII-styled, markdown, csv)</Description>
-      <Copyright>Andreas Pouwels</Copyright>
-      <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-      <Title>ZimLabs.TableCreator</Title>
-      <Version>2.1.1</Version>
-      <PackageProjectUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</PackageProjectUrl>
-      <PackageIcon>Logo.png</PackageIcon>
-      <PackageReadmeFile>readme.md</PackageReadmeFile>
-      <RepositoryUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</RepositoryUrl>
-      <RepositoryType>git</RepositoryType>
-      <PackageTags>helper, table, markdown, csv, ascii, output</PackageTags>
-      <PackageReleaseNotes>BREAKING CHANGE: Updated the framework from .NET Standard to .NET 7</PackageReleaseNotes>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <GenerateDocumentationFile>True</GenerateDocumentationFile>
-      <LangVersion>latest</LangVersion>
+    <Authors>Andreas Pouwels</Authors>
+    <Description>Library to convert a list of values into a "table" (ASCII-styled, markdown, csv)</Description>
+    <Copyright>Andreas Pouwels</Copyright>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Title>ZimLabs.TableCreator</Title>
+    <Version>2.1.1</Version>
+    <PackageProjectUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</PackageProjectUrl>
+    <PackageIcon>Logo.png</PackageIcon>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>helper, table, markdown, csv, ascii, output</PackageTags>
+    <PackageReleaseNotes>BREAKING CHANGE: Updated the framework from .NET Standard to .NET 7</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\Logo.png">
       <Pack>True</Pack>
@@ -32,5 +30,4 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
 </Project>

--- a/ZimLabs.TableCreator/ZimLabs.TableCreator.csproj
+++ b/ZimLabs.TableCreator/ZimLabs.TableCreator.csproj
@@ -8,14 +8,16 @@
     <Copyright>Andreas Pouwels</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>ZimLabs.TableCreator</Title>
-    <Version>2.1.1</Version>
+    <Version>3.0.0</Version>
+      <AssemblyVersion>3.0.0</AssemblyVersion>
+      <FileVersion>3.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</PackageProjectUrl>
     <PackageIcon>Logo.png</PackageIcon>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/InvaderZim85/ZimLabs.TableCreator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>helper, table, markdown, csv, ascii, output</PackageTags>
-    <PackageReleaseNotes>BREAKING CHANGE: Updated the framework from .NET Standard to .NET 7</PackageReleaseNotes>
+    <PackageReleaseNotes>BREAKING CHANGE: Updated the framework from .NET 7 / 8 to .NET 9.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
- Change from .NET 7 / .NET 8 to .NET 9
- Added new property `EncapsulateText` which can be used to indicates that text values should be encapsulated with quotation marks (only for CSV type). For example: `1;Test value;2` > `1;"Test value";2`